### PR TITLE
Allow offset to accept multiple polygons, and some build cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ categories = ["algorithms", "external-ffi-bindings"]
 
 [build-dependencies]
 bindgen = "0.53.1"
-cmake = "0.1.42"
+cc = "1.0.59"

--- a/build.rs
+++ b/build.rs
@@ -4,10 +4,11 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let clipper = cmake::build("clipper");
-
-    println!("cargo:rustc-link-search=native={}", clipper.display());
-    println!("cargo:rustc-link-lib=static=clipper");
+    cc::Build::new()
+        .cpp(true)
+        .file("clipper/clipper.cpp")
+        .file("clipper/wrapper.cpp")
+        .compile("clipper");
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();

--- a/clipper/clipper.cpp
+++ b/clipper/clipper.cpp
@@ -264,6 +264,8 @@ class Int128
     Int128(const Int128 &val): lo(val.lo), hi(val.hi){}
 
     Int128(const long64& _hi, const ulong64& _lo): lo(_lo), hi(_hi){}
+
+    Int128& operator = (const Int128&) = default;
     
     Int128& operator = (const long64 &val)
     {
@@ -718,7 +720,7 @@ void DisposeOutPts(OutPt*& pp)
 
 inline void InitEdge(TEdge* e, TEdge* eNext, TEdge* ePrev, const IntPoint& Pt)
 {
-  std::memset(e, 0, sizeof(TEdge));
+  *e = TEdge();
   e->Next = eNext;
   e->Prev = ePrev;
   e->Curr = Pt;
@@ -4329,10 +4331,10 @@ double DistanceFromLineSqrd(
   const IntPoint& pt, const IntPoint& ln1, const IntPoint& ln2)
 {
   //The equation of a line in general form (Ax + By + C = 0)
-  //given 2 points (x¹,y¹) & (x²,y²) is ...
-  //(y¹ - y²)x + (x² - x¹)y + (y² - y¹)x¹ - (x² - x¹)y¹ = 0
-  //A = (y¹ - y²); B = (x² - x¹); C = (y² - y¹)x¹ - (x² - x¹)y¹
-  //perpendicular distance of point (x³,y³) = (Ax³ + By³ + C)/Sqrt(A² + B²)
+  //given 2 points (xï¿½,yï¿½) & (xï¿½,yï¿½) is ...
+  //(yï¿½ - yï¿½)x + (xï¿½ - xï¿½)y + (yï¿½ - yï¿½)xï¿½ - (xï¿½ - xï¿½)yï¿½ = 0
+  //A = (yï¿½ - yï¿½); B = (xï¿½ - xï¿½); C = (yï¿½ - yï¿½)xï¿½ - (xï¿½ - xï¿½)yï¿½
+  //perpendicular distance of point (xï¿½,yï¿½) = (Axï¿½ + Byï¿½ + C)/Sqrt(Aï¿½ + Bï¿½)
   //see http://en.wikipedia.org/wiki/Perpendicular_distance
   double A = double(ln1.Y - ln2.Y);
   double B = double(ln2.X - ln1.X);

--- a/clipper/wrapper.h
+++ b/clipper/wrapper.h
@@ -88,7 +88,7 @@ Polygons offset(
     double round_precision,
     JoinType join_type,
     EndType end_type,
-    Polygon polygons,
+    Polygons polygons,
     double delta);
 
 void free_path(Path path);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -163,15 +163,19 @@ fn test_difference() {
 
 #[test]
 fn test_offset() {
-    let polygon = Polygon {
-        type_: PolyType_ptSubject,
-        paths: [Path {
-            vertices: [[100, 100], [100, 200], [200, 200], [200, 100]].as_mut_ptr(),
-            vertices_count: 4,
-            closed: 1,
+    let polygons = Polygons {
+        polygons: [Polygon {
+            type_: PolyType_ptSubject,
+            paths: [Path {
+                vertices: [[100, 100], [100, 200], [200, 200], [200, 100]].as_mut_ptr(),
+                vertices_count: 4,
+                closed: 1,
+            }]
+            .as_mut_ptr(),
+            paths_count: 1,
         }]
         .as_mut_ptr(),
-        paths_count: 1,
+        polygons_count: 1,
     };
 
     let expected = Polygon {
@@ -201,7 +205,7 @@ fn test_offset() {
             /*round_precision=*/ 0.25,
             JoinType_jtSquare,
             EndType_etClosedPolygon,
-            polygon,
+            polygons,
             5.,
         );
 


### PR DESCRIPTION
This PR includes two small changes. 

The first is a minor build cleanup. I change the build.rs to use cc::Build instead of cmake. This builds faster than cmake and removes a dependency on an external build tool. In addition, I cleaned up signed/unsigned comparison warnings in wrapper.cpp that are now surfaced. I opted not to clean up clipper.cpp because that is external code.

Second, I modified the interface to offset to allow a Polygons list. I have a parallel PR almost ready for geo-clipper that uses this to provide offsetting for geo::MultiPolygon.