### PR TITLE
Fix_orientation_before_offset

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -30,7 +30,7 @@ fn main() {
     #[cfg(feature = "generate-bindings")]
     {
         let bindings = bindgen::Builder::default()
-            .header("clipper/wrapper.h")
+            .header("clipper/wrapper.hpp")
             .allowlist_type("Polygons")
             .allowlist_type("ClipType")
             .allowlist_type("JoinType")

--- a/build.rs
+++ b/build.rs
@@ -44,6 +44,7 @@ fn main() {
             .allowlist_function("simplify")
             .allowlist_function("execute")
             .allowlist_function("offset")
+            .allowlist_function("offset_simplify_clean")
             .allowlist_function("free_path")
             .allowlist_function("free_polygon")
             .allowlist_function("free_polygons")

--- a/clipper/wrapper.cpp
+++ b/clipper/wrapper.cpp
@@ -1,4 +1,4 @@
-#include "wrapper.h"
+#include "wrapper.hpp"
 #include "clipper.hpp"
 #include <iostream>
 #include <queue>

--- a/clipper/wrapper.hpp
+++ b/clipper/wrapper.hpp
@@ -83,6 +83,16 @@ Polygons execute(
     PolyFillType subject_fill_type,
     PolyFillType clip_fill_type);
 
+Polygons offset_simplify_clean(
+    Polygons polygons,
+    double miter_limit,
+    double round_precision,
+    JoinType join_type,
+    EndType end_type,
+    double delta,
+    PolyFillType fill_type = PolyFillType::pftEvenOdd,
+    double distance = 0.5);
+
 Polygons offset(
     double miter_limit,
     double round_precision,
@@ -91,13 +101,13 @@ Polygons offset(
     Polygons polygons,
     double delta);
 
-    Polygons simplify(
-        Polygons polygons,
-        PolyFillType fill_type);
+Polygons simplify(
+    Polygons polygons,
+    PolyFillType fill_type);
 
-    Polygons clean(
-        Polygons polygons,
-        double distance);
+Polygons clean(
+    Polygons polygons,
+    double distance);
 
 void free_path(Path path);
 void free_polygon(Polygon polygon);


### PR DESCRIPTION
This update partially solves the orientation problem that comes with using the `ClipperOffset` struct. `ClipperOffset` requires the input polygons to be of a strict orientation, i.e. outer polygons must rotate one way whilst inner polygons the other. Note that an inner polygon of an inner polygon itself is again an outer polygon and thus must be rotate like the outermost polygon. Also see [preconditions for the ClipperOffset struct](http://www.angusj.com/delphi/clipper/documentation/Docs/Units/ClipperLib/Classes/ClipperOffset/_Body.htm).

This knowledge is not yet documented anywhere. Still I find this information highly valuable as the outcome is quite confusing, if the user does not orient his input polygons correctly. I suggest it be documented a level higher on the `Rust` level in the geo-clipper crate?

For reasons concerning computational efficiency, I also added an extended offset function `offset_simplify_clean`, which calls the functions `offset`, `simplify` and `clean` without changing the `C++` context to `Rust` back and forth.