### PR TITLE
build: fix mac os error during build time

### DIFF
--- a/clipper/wrapper.cpp
+++ b/clipper/wrapper.cpp
@@ -20,7 +20,7 @@ ClipperLib::Path get_path(const Path& path)
     return clipper_path;
 }
 
-std::pair<Paths, std::vector<bool>> get_polygon_paths(const Polygon& polygon)
+std::pair<Paths, std::vector<bool> > get_polygon_paths(const Polygon& polygon)
 {
     Paths paths;
     paths.reserve(polygon.paths_count);


### PR DESCRIPTION
will fix https://github.com/lelongg/geo-clipper/issues/14

the initial error ` error: a space is required between consecutive right angle brackets (use '> >')`