### PR TITLE
fix macos build

### DIFF
--- a/clipper/wrapper.cpp
+++ b/clipper/wrapper.cpp
@@ -22,7 +22,7 @@ ClipperLib::Path get_path(const Path &path)
     return clipper_path;
 }
 
-std::pair<Paths, std::vector<bool>> get_polygon_paths(const Polygon &polygon)
+std::pair<Paths, std::vector<bool> > get_polygon_paths(const Polygon &polygon)
 {
     Paths paths;
     paths.reserve(polygon.paths_count);


### PR DESCRIPTION
Hello :wave:

the last release of geo-clipper has bumped the clipper-sys, which doesn't compile on macos.

```
clipper/wrapper.cpp:25:34: error: a space is required between consecutive right angle brackets (use '> >')
std::pair<Paths, std::vector<bool>> get_polygon_paths(const Polygon &polygon)
```

once merged, could you release a new patch ? :)